### PR TITLE
Allow https to be used with S3 without a cert error

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ exports.urlSigner = function(key, secret, options){
   };
 
   var url = function (fname, bucket) {
-    return protocol + '://'+ bucket + '.' + endpoint + (port != 80 ? ':' + port : '') + (fname[0] === '/'?'':'/') + fname;
+    return protocol + '://'+ endpoint + (port != 80 ? ':' + port : '') + '/' + bucket + (fname[0] === '/'?'':'/') + fname;
   };
 
   return {


### PR DESCRIPTION
The signer was always using http[s]://[bucket].s3.amazonaws.com/[object]. This doesn't work with SSL. So I flipped it to default to http[s]://s3.amazonaws.com/[bucket]/[path] so that we can use amazon's SSL cert without error.

This works for all of my uses, but might break for other users. Maybe I should write some tests to make sure all uses are covered?

Thanks for your great work!
