### PR TITLE
Allow the specification to use subdomain-based urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,7 @@ exports.urlSigner = function(key, secret, options){
 
       var epo = Math.floor(expires.getTime()/1000);
 
-      var str;
-      if (subdomain) {
-        str = verb + '\n\n\n' + epo + '\n' + (fname[0] === '/'?'':'/') + fname;
-      } else {
-        str = verb + '\n\n\n' + epo + '\n' + '/' + bucket + (fname[0] === '/'?'':'/') + fname;
-      }
+      var str = verb + '\n\n\n' + epo + '\n' + '/' + bucket + (fname[0] === '/'?'':'/') + fname;
 
       var hashed = hmacSha1(str);
 


### PR DESCRIPTION
There are two types of amazon urls:
http://mybucket.s3.amazonaws.com/keypath
http://s3.amazonaws.com/bucket/keypath

There are configurations such that if you ask for a file on the latter path, it will give you a 301 and tell you to access based on the subdomain-based path. It'd be great to specify how you want the url so you can avoid the extra hop.
